### PR TITLE
fix(kanctl) remove namespace from args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/kubectl:1.21
 
 USER root
 
-RUN /bin/bash -c "curl -L https://github.com/SwissDataScienceCenter/taweret/releases/download/v0.2.0-beta/taweret_0.2.0-beta_Linux_x86_64.tar.gz | tar xvz -C /usr/local/bin/; \
+RUN /bin/bash -c "curl -L https://github.com/SwissDataScienceCenter/taweret/releases/download/v0.2.0-beta2/taweret_0.2.0-beta2_Linux_x86_64.tar.gz | tar xvz -C /usr/local/bin/; \
 curl -L https://github.com/kanisterio/kanister/releases/download/0.78.0/kanister_0.78.0_linux_amd64.tar.gz | tar xvz -C /usr/local/bin/"
 
 USER 1001

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func sortBackups(backups []backup) []backup {
 func deleteBackup(unusedBackup backup, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, kanisterNamespace string, blueprintName string, s3ProfileName string) {
 
 	//create kanctl deletion actionset
-	args := []string{"create", "actionset", "--action", "delete", "--from", unusedBackup.name, "--blueprint", blueprintName, "--profile", s3ProfileName, "--namespacetargets", kanisterNamespace, "-n", kanisterNamespace}
+	args := []string{"create", "actionset", "--action", "delete", "--from", unusedBackup.name, "--blueprint", blueprintName, "--profile", s3ProfileName, "--namespacetargets", kanisterNamespace}
 	cmd := exec.Command("/usr/local/bin/kanctl", args...)
 	stdout, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Remove namespace from kanctl args, as the kanctl command is run using a limited service account, which cannot list the ns